### PR TITLE
exclude .inline images from featherlight

### DIFF
--- a/static/js/hugo-learn.js
+++ b/static/js/hugo-learn.js
@@ -17,7 +17,7 @@ var getUrlParameter = function getUrlParameter(sPageURL) {
 };
 
 // Execute actions on images generated from Markdown pages
-var images = $("div#body-inner img");
+var images = $("div#body-inner img").not(".inline");
 // Wrap image inside a featherlight (to get a full size view in a popup)
 images.wrap(function(){
   var image =$(this);


### PR DESCRIPTION
exclude .inline images from featherlight, so that for instance Badges can be used.