### PR TITLE
feat: add icon on menu which have children + fix attachements shortcode

### DIFF
--- a/exampleSite/content/shortcode/attachments.md
+++ b/exampleSite/content/shortcode/attachments.md
@@ -9,9 +9,8 @@ identifier = "attachments"
 
 The Attachments shortcode displays a list of files attached to a page.  
 Example :
-{{%alert success%}}
-{{%attachments  /%}}
-{{%/alert%}}
+{{%alert success%}}{{%attachments  /%}}{{%/alert%}}
+
 ## Usage 
 
 The shortcurt lists files found in a **folder** named like your page and ending with **.files**.
@@ -33,10 +32,6 @@ For example:
 * To match file names ending in 'jpg' or 'png', use **.*(jpg|png)**
 
 {{%/alert%}}|
-
-
-
-
 
 
 ## Demo

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -62,6 +62,13 @@
         {{if ($currentNode.HasMenuCurrent "main" .menu) }}parent{{end}}">
             <a href="{{.menu.URL}}">
                 {{.menu.Pre}}{{.menu.Name}}{{.menu.Post}}
+                {{ if .menu.HasChildren }}
+                    {{if or ($currentNode.IsMenuCurrent "main" .menu) ($currentNode.HasMenuCurrent "main" .menu)}}
+                        <i class="fa fa-angle-down fa-lg category-icon"></i>
+                    {{else}}
+                        <i class="fa fa-angle-right fa-lg category-icon"></i>
+                    {{end}}
+                {{end}}
                 {{ if $showvisitedlinks}}<i style="color:grey" class="fa fa-check read-icon"></i>{{end}}
             </a>
             {{ if or ($currentNode.IsMenuCurrent "main" .menu) ($currentNode.HasMenuCurrent "main" .menu) }}

--- a/layouts/shortcodes/attachments.html
+++ b/layouts/shortcodes/attachments.html
@@ -6,16 +6,18 @@
 		{{if ($.Get "pattern")}}
 			{{if (findRE ($.Get "pattern") .Name)}}
 				<li>
-				<a 
-				href="{{ printf "%s/%s%s.files/%s" $.Site.BaseURL $.Page.File.Dir $.Page.File.BaseFileName .Name }}" 
-				title="Dernière modification le {{(time .ModTime).Format "02/01/2006 à 15h04" }}" >{{.Name}}</a> ({{div .Size 1024 }} ko)
+					<a href="{{ printf "%s/%s%s.files/%s" $.Site.BaseURL $.Page.File.Dir $.Page.File.BaseFileName .Name }}" >
+						{{.Name}}
+					</a>
+					({{div .Size 1024 }} ko)
 				</li>
 			{{end}}
 		{{else}}
 			<li>
-				<a 
-				href="{{ printf "%s/%s%s.files/%s" $.Site.BaseURL $.Page.File.Dir $.Page.File.BaseFileName .Name }}" 
-				title="Dernière modification le {{(time .ModTime).Format "02/01/2006 à 15h04" }}" >{{.Name}}</a> ({{div .Size 1024 }} ko)
+				<a href="{{ printf "%s/%s%s.files/%s" $.Site.BaseURL $.Page.File.Dir $.Page.File.BaseFileName .Name }}" >
+					{{.Name}}
+				</a>
+				({{div .Size 1024 }} ko)
 			</li>
 		{{end}}
 	{{end}}

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -318,10 +318,7 @@ textarea:focus, input[type="email"]:focus, input[type="number"]:focus, input[typ
 }
 #sidebar ul li > a {
     padding: 4px 0;
-}
-#sidebar ul li.visited > a .read-icon {
-    color: #183f81;
-    display: inline;
+    position: relative;
 }
 #sidebar ul li li {
     padding-left: 1rem;
@@ -1011,20 +1008,34 @@ pre .copy-to-clipboard:hover {
     transform-style: preserve-3d;
 }
 
-#sidebar ul.topics > li > a .read-icon {
-    margin-top: 9px;
-}
 #sidebar ul li .read-icon {
     display: none;
     float: right;
-    font-size: 13px;
-    min-width: 16px;
-    margin: 4px 0 0 0;
-    text-align: right;
+    position: absolute;
+    right: 25px;
+    margin: 0 !important;
+    top: 9px;
 }
 #sidebar ul li.visited > a .read-icon {
     color: #2053AB;
-    display: inline;
+    display: block;
+}
+#sidebar ul li.visited.active > a .read-icon {
+    right: 40px;
+}
+
+#sidebar ul li .category-icon {
+    color: grey;
+    display: block;
+    float: right;
+    position: absolute;
+    right: 0px;
+    margin: 0 !important;
+    top: 9px;
+}
+
+#sidebar ul li.active > a .category-icon {
+    right: 15px;
 }
 
 #sidebar #shortcuts h3 {
@@ -1046,9 +1057,6 @@ pre .copy-to-clipboard:hover {
     padding-top: 0px;
     margin-bottom:  0px;
     padding-bottom: 0px;
-}
-.children-li li {
-        
 }
 .children-li p {
     font-size: small;


### PR DESCRIPTION
Currently there is no distinction between menus which have children and the others.

So I added a "fa fa-angle-right/down" icon on the concerned menus.
I also removed the title on attachments.html which broke the shortcode. 