### PR TITLE
change search results to use full uri

### DIFF
--- a/layouts/index.json
+++ b/layouts/index.json
@@ -2,7 +2,7 @@
 {{- if ne $page.Type "json" -}}
 {{- if and $index (gt $index 0) -}},{{- end }}
 {
-	"uri": "{{ $page.RelPermalink }}",
+	"uri": "{{ $page.Permalink }}",
 	"title": "{{ htmlEscape $page.Title}}",
 	"tags": [{{ range $tindex, $tag := $page.Params.tags }}{{ if $tindex }}, {{ end }}"{{ $tag| htmlEscape }}"{{ end }}],
 	"description": "{{ htmlEscape .Description}}",

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -68,7 +68,7 @@ $( document ).ready(function() {
             return true;
         },
         set: function (value) {
-            location.href=value.href;
+            location.href=value.uri;
         },
         render: function (li, suggestion) {
             var uri = suggestion.uri.substring(1,suggestion.uri.length);


### PR DESCRIPTION
Appending relative url's to the base url doesn't work when the base url is not at the root of a domain.

Example:
Having the baseURL=https://my-docs/my-project will result in search results that have 'my-project' twice so in this case it would be https://my-docs/my-project/my-project/result.html instead of the desired https://my-docs/my-project/result.html.

I might be doing something wrong here but the only fix I could get working involved moving to absolute urls in the search results.