### PR TITLE
feat: modify attachments to be compatible with pages based on folders

### DIFF
--- a/layouts/shortcodes/attachments.html
+++ b/layouts/shortcodes/attachments.html
@@ -1,12 +1,18 @@
 <section class="attachments">
-	<label><span class="glyphicon glyphicon-paperclip" aria-hidden="true"></span> 
-	{{with .Get "title"}}{{.}}{{else}}Attachments{{end}}
+	<label>
+		<span class="glyphicon glyphicon-paperclip" aria-hidden="true"></span>
+		{{with .Get "title"}}{{.}}{{else}}Attachments{{end}}
 	</label>
-	{{ range (readDir (printf "./content/%s%s.files" .Page.File.Dir .Page.File.BaseFileName) ) }}
+	{{if eq .Page.File.BaseFileName "index"}}
+		{{$.Scratch.Add "filesName" "files"}}
+	{{else}}
+		{{$.Scratch.Add "filesName" (printf "%s.files" .Page.File.BaseFileName)}}
+	{{end}}
+	{{ range (readDir (printf "./content/%s%s" .Page.File.Dir ($.Scratch.Get "filesName")) ) }}
 		{{if ($.Get "pattern")}}
 			{{if (findRE ($.Get "pattern") .Name)}}
 				<li>
-					<a href="{{ printf "%s/%s%s.files/%s" $.Site.BaseURL $.Page.File.Dir $.Page.File.BaseFileName .Name }}" >
+					<a href="{{ printf "%s/%s%s/%s" $.Site.BaseURL $.Page.File.Dir ($.Scratch.Get "filesName") .Name }}" >
 						{{.Name}}
 					</a>
 					({{div .Size 1024 }} ko)
@@ -14,7 +20,7 @@
 			{{end}}
 		{{else}}
 			<li>
-				<a href="{{ printf "%s/%s%s.files/%s" $.Site.BaseURL $.Page.File.Dir $.Page.File.BaseFileName .Name }}" >
+				<a href="{{ printf "%s/%s%s/%s" $.Site.BaseURL $.Page.File.Dir ($.Scratch.Get "filesName") .Name }}" >
 					{{.Name}}
 				</a>
 				({{div .Size 1024 }} ko)


### PR DESCRIPTION
now attachements supports:
- content
	- page.files
		- attachment.pdf
	- page.md
	- _index.md

and
- content
	- page
		- index.md
		- files
			- attachment.pdf
	- _index.md