### PR TITLE
Fix div.notices css to support multi-paragraph

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -717,7 +717,7 @@ div.notices p {
 }
 div.notices p:first-child:before {
     position: absolute;
-    top: 2px;
+    top: -27px;
     color: #fff;
     font-family: FontAwesome;
     content: '';
@@ -725,32 +725,32 @@ div.notices p:first-child:before {
 }
 div.notices p:first-child:after {
     position: absolute;
-    top: 2px;
+    top: -27px;
     color: #fff;
     left: 2rem;
 }
-div.notices.info p {
+div.notices.info {
     border-top: 30px solid #F0B37E;
     background: #FFF2DB;
 }
 div.notices.info p:first-child:after {
     content: 'Info';
 }
-div.notices.warning p {
+div.notices.warning {
     border-top: 30px solid rgba(217, 83, 79, 0.8);
     background: #FAE2E2;
 }
 div.notices.warning p:first-child:after {
     content: 'Warning';
 }
-div.notices.note p {
+div.notices.note {
     border-top: 30px solid #6AB0DE;
     background: #E7F2FA;
 }
 div.notices.note p:first-child:after {
     content: 'Note';
 }
-div.notices.tip p {
+div.notices.tip {
     border-top: 30px solid rgba(92, 184, 92, 0.8);
     background: #E6F9E6;
 }


### PR DESCRIPTION
Changes to resolve #13 

732, 739, 746, 753:
Border element for each notices.XXXX now applies to all elements, not just p
    - this is what was causing the title bar to render at the top of each notices \<p\> before

720, 728:
Adjusts pixel position of first-child:before and first-child:after of (first) \<p\> to correctly place content, now that title bar is outside of \<p\> element.
    - kept these changes using absolute pixel references as found.
    - Not 100% sure of compatibility across platforms when done that way though.

Sample file for testing included in issue #13 

Thanks