### PR TITLE
Default archetype updated: avoid warning

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,6 +1,9 @@
 +++
-title = "Create Page"
+title= "{{ replace .TranslationBaseName "-" " " | title }}"
+date= {{ .Date }}
 description = ""
+draft= true
 +++
 
-Lorem Ipsum
+Lorem Ipsum.
+Notice `draft` is set to true.


### PR DESCRIPTION
Date param added to frontmatter to avoid warning with Hugo version 0.24.
Besides `title` is set up using the filename and draft param has been added by default.