### PR TITLE
Open shortcut links in new tab.

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -37,7 +37,7 @@
             {{ range sort . "Weight"}}
                 <li class="" role="">
                     {{.Pre}}
-                    <a href="{{.URL}}">{{safeHTML .Name}}</a>
+                    <a href="{{.URL}}" target="_blank" rel="noopener">{{safeHTML .Name}}</a>
                     {{.Post}}
                 </li>
             {{end}}


### PR DESCRIPTION
Those shortcuts most likely are collection of external URL's. It is very frustrating to navigate web and especially documentations when external sites opens in current tab and location is _lost_.

P.S. [rel=noopener makes it faster and secure](https://mathiasbynens.github.io/rel-noopener/). I always use it when linking outside current site.