### PR TITLE
Compress html whitespaces #61

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -10,45 +10,45 @@
 
     <div id="navigation">
         <!-- Next prev page -->
-        {{ $currentNode := . }}
-        
-        {{ template "menu-nextprev" dict "menu" .Site.Home "currentnode" $currentNode }}
-        
-        {{ define "menu-nextprev" }}
-            {{$currentNode := .currentnode }}
-            {{ if ne .menu.Params.hidden true}}
-                {{if hasPrefix $currentNode.URL .menu.URL }}
-                    {{ $currentNode.Scratch.Set "NextPageOK" "OK" }}
-                    {{ $currentNode.Scratch.Set "prevPage" ($currentNode.Scratch.Get "prevPageTmp") }}
-                {{else}}
-                    {{if eq ($currentNode.Scratch.Get "NextPageOK") "OK"}}
-                        {{ $currentNode.Scratch.Set "NextPageOK" nil }}
-                        {{ $currentNode.Scratch.Set "nextPage" .menu }}
-                    {{end}}
-                {{end}}
-                {{ $currentNode.Scratch.Set "prevPageTmp" .menu }}
+        {{- $currentNode := . -}}
 
-                    {{ $currentNode.Scratch.Set "pages" .menu.Pages }}
-                    {{ if .menu.IsHome}}
-                        {{ $currentNode.Scratch.Set "pages" .menu.Sections }}
-                    {{ else if .menu.Sections}}
-                        {{ $currentNode.Scratch.Set "pages" (.menu.Pages | union .menu.Sections) }}
-                    {{end}}
-                    {{ $pages := ($currentNode.Scratch.Get "pages") }}
+        {{- template "menu-nextprev" dict "menu" .Site.Home "currentnode" $currentNode -}}
 
-                    {{ range $pages.ByWeight  }}
-                        {{ template "menu-nextprev" dict "menu" . "currentnode" $currentNode }}
-                    {{end}}
-            {{ end }}
-        {{ end }}
+        {{- define "menu-nextprev" -}}
+            {{- $currentNode := .currentnode -}}
+            {{- if ne .menu.Params.hidden true -}}
+                {{- if hasPrefix $currentNode.URL .menu.URL -}}
+                    {{- $currentNode.Scratch.Set "NextPageOK" "OK" -}}
+                    {{- $currentNode.Scratch.Set "prevPage" ($currentNode.Scratch.Get "prevPageTmp") -}}
+                {{- else -}}
+                    {{- if eq ($currentNode.Scratch.Get "NextPageOK") "OK" -}}
+                        {{- $currentNode.Scratch.Set "NextPageOK" nil -}}
+                        {{- $currentNode.Scratch.Set "nextPage" .menu -}}
+                    {{- end -}}
+                {{- end -}}
+                {{- $currentNode.Scratch.Set "prevPageTmp" .menu -}}
+
+                    {{- $currentNode.Scratch.Set "pages" .menu.Pages -}}
+                    {{- if .menu.IsHome -}}
+                        {{- $currentNode.Scratch.Set "pages" .menu.Sections -}}
+                    {{- else if .menu.Sections -}}
+                        {{- $currentNode.Scratch.Set "pages" (.menu.Pages | union .menu.Sections) -}}
+                    {{- end -}}
+                    {{- $pages := ($currentNode.Scratch.Get "pages") -}}
+
+                    {{- range $pages.ByWeight -}}
+                        {{- template "menu-nextprev" dict "menu" . "currentnode" $currentNode -}}
+                    {{- end -}}
+            {{- end -}}
+        {{- end -}}
 
 
-        {{with ($.Scratch.Get "prevPage")}}
+        {{- with ($.Scratch.Get "prevPage") -}}
             <a class="nav nav-prev" href="{{.URL}}" title="{{.Title}}"> <i class="fa fa-chevron-left"></i></a>
-        {{end}}
-        {{with ($.Scratch.Get "nextPage")}}
+        {{ end -}}
+        {{- with ($.Scratch.Get "nextPage") -}}
             <a class="nav nav-next" href="{{.URL}}" title="{{.Title}}" style="margin-right: 0px;"><i class="fa fa-chevron-right"></i></a>
-        {{end}}
+        {{- end }}
     </div>
 
     </section>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -49,8 +49,8 @@
                 {{T "Edit-this-page"}}
               </a>
             </div>
-              {{ end }}
-            {{ end }}
+              {{- end }}
+            {{- end -}}
 
             <div id="breadcrumbs" itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb">
                 <span id="sidebar-toggle-span">

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,126 +1,126 @@
 <nav id="sidebar" class="{{if $.Site.Params.showVisitedLinks }}showVisitedLinks{{end}}">
 
+{{- $currentNode := . }}
+{{- $showvisitedlinks := .Site.Params.showVisitedLinks -}}
 
-
-{{ $currentNode := . }}
-{{ $showvisitedlinks := .Site.Params.showVisitedLinks }}
 <div class="highlightable">
   <div id="header-wrapper">
     <div id="header">
-      {{ partial "logo.html" . }}
+      {{- partial "logo.html" . }}
     </div>
-    {{if not .Site.Params.noSearch}}
-        {{ partial "search.html" . }}
-    {{end}}
+    {{- if not .Site.Params.noSearch}}
+        {{- partial "search.html" . }}
+    {{- end}}
   </div>
 
-  
+
     <ul class="topics">
-        {{if not .Site.Params.noHomeIcon}}
+        {{- if not .Site.Params.noHomeIcon}}
             <li data-nav-id="{{"/" | relURL}}" class="dd-item">
             <a href="{{"/" | relURL}}"><i class="fa fa-fw fa-home"></i></a>
             </li>
-        {{end}}
-        
-        {{if eq .Site.Params.ordersectionsby "title"}}  
-          {{range .Site.Home.Sections.ByTitle}}
-          {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks}}
-          {{end}}
-        {{else}}
-          {{range .Site.Home.Sections.ByWeight}}
-          {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks}}
-          {{end}}
-        {{end}}
+        {{- end}}
 
-        {{with .Site.Menus.shortcuts}}
+        {{- if eq .Site.Params.ordersectionsby "title"}}
+          {{- range .Site.Home.Sections.ByTitle}}
+          {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks}}
+          {{- end}}
+        {{- else}}
+          {{- range .Site.Home.Sections.ByWeight}}
+          {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks}}
+          {{- end}}
+        {{- end}}
+
+        {{- with .Site.Menus.shortcuts}}
         <section id="shortcuts">
-            {{ range sort . "Weight"}}
+            {{- range sort . "Weight"}}
                 <li class="" role="">
-                    {{.Pre}}
+                    {{- .Pre -}}
                     <a href="{{.URL}}" target="_blank" rel="noopener">{{safeHTML .Name}}</a>
-                    {{.Post}}
+                    {{- .Post -}}
                 </li>
-            {{end}}
-        </section>    
-        
-        {{ if $.Site.Params.showVisitedLinks}}
-            <a class="" href="#" data-clear-history-toggle=""><i class="fa  fa-history"></i> {{T "Clear-History"}}</a>
-        {{ end }}
+            {{- end}}
+        </section>
 
-        {{end}}
+        {{- if $.Site.Params.showVisitedLinks}}
+            <a class="" href="#" data-clear-history-toggle=""><i class="fa  fa-history"></i> {{T "Clear-History"}}</a>
+        {{- end}}
+
+        {{- end}}
     </ul>
-    
-     
+
+
     <section id="footer">
-      {{ partial "menu-footer.html" . }}
+      {{- partial "menu-footer.html" . }}
     </section>
   </div>
 </nav>
 
 <!-- templates -->
-{{ define "section-tree-nav" }}
-{{ $showvisitedlinks := .showvisitedlinks }}
-{{ $currentNode := .currentnode }}
- {{with .sect}}
-  {{if .IsSection}}
-    {{safeHTML .Params.head}}
-    <li data-nav-id="{{.URL}}" class="dd-item 
-        {{if .IsAncestor $currentNode }}parent{{end}}
-        {{if eq .UniqueID $currentNode.UniqueID}}active{{end}}
-        {{if .Params.alwaysopen}}parent{{end}}
+{{- define "section-tree-nav" }}
+{{- $showvisitedlinks := .showvisitedlinks }}
+{{- $currentNode := .currentnode }}
+ {{- with .sect}}
+  {{- if .IsSection}}
+    {{- safeHTML .Params.head}}
+    <li data-nav-id="{{.URL}}" class="dd-item
+        {{- if .IsAncestor $currentNode}}parent{{end}}
+        {{- if eq .UniqueID $currentNode.UniqueID}}active{{end}}
+        {{- if .Params.alwaysopen}}parent{{end -}}
         ">
       <a href="{{ .RelPermalink}}">
         <span>{{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}</span>
 
-        {{ $numberOfPages := (add (len .Pages) (len .Sections)) }}
-        {{ if ne $numberOfPages 0 }}
+        {{- $numberOfPages := (add (len .Pages) (len .Sections)) }}
+        {{- if ne $numberOfPages 0 }}
 
-          {{if or (.IsAncestor $currentNode) (.Params.alwaysopen) }}
+          {{- if or (.IsAncestor $currentNode) (.Params.alwaysopen) }}
             <i class="fa fa-angle-down fa-lg category-icon"></i>
-          {{else}}
+          {{- else -}}
             <i class="fa fa-angle-right fa-lg category-icon"></i>
-          {{end}}
+          {{- end}}
 
-        {{ end }}
+        {{- end}}
 
-        {{ if $showvisitedlinks}}<i style="color:grey" class="fa fa-circle-thin read-icon"></i>{{end}}
+        {{- if $showvisitedlinks}}<i style="color:grey" class="fa fa-circle-thin read-icon"></i>{{end}}
       </a>
-      {{ if ne $numberOfPages 0 }}
+      {{- if ne $numberOfPages 0 }}
         <ul>
-          {{ .Scratch.Set "pages" .Pages }}
-          {{ if .Sections}}
-          {{ .Scratch.Set "pages" (.Pages | union .Sections) }}
-          {{end}}
-          {{ $pages := (.Scratch.Get "pages") }}
-          
-        {{if eq .Site.Params.ordersectionsby "title"}}  
-          {{ range $pages.ByTitle }}
-            {{ if and .Params.hidden (not $.showhidden) }} 
-            {{else}}
-            {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks }}
-            {{end}}
-          {{ end }}
-        {{else}}
-          {{ range $pages.ByWeight }}
-            {{ if and .Params.hidden (not $.showhidden) }} 
-            {{else}}
-            {{ template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks }}
-            {{end}}
-          {{ end }}
-        {{end}}
+          {{- .Scratch.Set "pages" .Pages }}
+          {{- if .Sections}}
+          {{- .Scratch.Set "pages" (.Pages | union .Sections) }}
+          {{- end}}
+          {{- $pages := (.Scratch.Get "pages") }}
+
+        {{- if eq .Site.Params.ordersectionsby "title"}}
+          {{- range $pages.ByTitle }}
+            {{- if and .Params.hidden (not $.showhidden) }}
+            {{- else}}
+            {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks }}
+            {{- end}}
+          {{- end}}
+        {{- else}}
+          {{- range $pages.ByWeight }}
+            {{- if and .Params.hidden (not $.showhidden) }}
+            {{- else}}
+            {{- template "section-tree-nav" dict "sect" . "currentnode" $currentNode "showvisitedlinks" $showvisitedlinks }}
+            {{- end}}
+          {{- end}}
+        {{- end}}
         </ul>
-      {{ end }}        
+      {{- end}}
     </li>
-  {{else}}
-    {{ if not .Params.Hidden }}
+  {{- else}}
+    {{- if not .Params.Hidden }}
       <li data-nav-id="{{.URL}}" class="dd-item
-     {{if eq .UniqueID $currentNode.UniqueID}}active{{end}}
+     {{- if eq .UniqueID $currentNode.UniqueID}}active{{end -}}
       ">
         <a href="{{ .RelPermalink}}">
-        <span>{{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}</span> 
-        {{ if $showvisitedlinks}}<i style="color:grey" class="fa fa-circle-thin read-icon"></i>{{end}}
-        </a></li>
-     {{ end }}
-  {{end}}
- {{ end }}
-{{ end }}
+          <span>{{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}</span>
+          {{- if $showvisitedlinks}}<i style="color:grey" class="fa fa-circle-thin read-icon"></i>{{end}}
+        </a>
+	  </li>
+     {{- end}}
+  {{- end}}
+ {{- end}}
+{{- end}}

--- a/layouts/shortcodes/children.html
+++ b/layouts/shortcodes/children.html
@@ -1,105 +1,105 @@
-{{ $showhidden := .Get "showhidden"}}
-{{ $style :=  .Get "style" | default "li" }}
-{{ $depth :=  .Get "depth" | default 1 }}
-{{ $withDescription :=  .Get "description" | default false }}
-{{ $sortTerm :=  .Get "sort" | default "Weight" }}
+{{- $showhidden := .Get "showhidden"}}
+{{- $style :=  .Get "style" | default "li" }}
+{{- $depth :=  .Get "depth" | default 1 }}
+{{- $withDescription :=  .Get "description" | default false }}
+{{- $sortTerm :=  .Get "sort" | default "Weight" }}
 
-{{ .Scratch.Set "current" .Page }}
+{{- .Scratch.Set "current" .Page }}
 
-{{if (.Get "page")}}
-	{{ with .Site.GetPage "section" (.Get "page") }}
-		{{ $.Scratch.Set "current" . }}
-	{{ end }}
-{{ end }}
+{{- if (.Get "page")}}
+	{{- with .Site.GetPage "section" (.Get "page") }}
+		{{- $.Scratch.Set "current" . }}
+	{{- end }}
+{{- end }}
 
-{{ $cpage := (.Scratch.Get "current") }}
+{{- $cpage := (.Scratch.Get "current") }}
 
 <ul class="children children-{{$style}}">
-	{{ .Scratch.Set "pages" $cpage.Pages }}
-    {{ if $cpage.Sections}}
-	    {{ .Scratch.Set "pages" ($cpage.Pages | union $cpage.Sections) }}
-    {{end}}
-    {{ $pages := (.Scratch.Get "pages") }}
+	{{- .Scratch.Set "pages" $cpage.Pages }}
+    {{- if $cpage.Sections}}
+	    {{- .Scratch.Set "pages" ($cpage.Pages | union $cpage.Sections) }}
+    {{- end}}
+    {{- $pages := (.Scratch.Get "pages") }}
 
-	{{if eq $sortTerm "Weight"}}
-		{{template "childs" dict "menu" $pages.ByWeight "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
-	{{else if eq $sortTerm "Name"}}
-		{{template "childs" dict "menu" $pages.ByTitle "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
-	{{else if eq $sortTerm "PublishDate"}}
-		{{template "childs" dict "menu" $pages.ByPublishDate "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
-	{{else if eq $sortTerm "Date"}}
-		{{template "childs" dict "menu" $pages.ByDate "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
-	{{else if eq $sortTerm "Length"}}
-		{{template "childs" dict "menu" $pages.ByLength "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
-	{{else}}
-		{{template "childs" dict "menu" $pages "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
+	{{- if eq $sortTerm "Weight"}}
+		{{- template "childs" dict "menu" $pages.ByWeight "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
+	{{- else if eq $sortTerm "Name"}}
+		{{- template "childs" dict "menu" $pages.ByTitle "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
+	{{- else if eq $sortTerm "PublishDate"}}
+		{{- template "childs" dict "menu" $pages.ByPublishDate "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
+	{{- else if eq $sortTerm "Date"}}
+		{{- template "childs" dict "menu" $pages.ByDate "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
+	{{- else if eq $sortTerm "Length"}}
+		{{- template "childs" dict "menu" $pages.ByLength "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
+	{{- else}}
+		{{- template "childs" dict "menu" $pages "style" $style "showhidden" $showhidden "count" 1 "depth" $depth "pages" .Site.Pages "description" $withDescription "sortTerm" $sortTerm}}
 	{{end}}
 </ul>
 
 {{.Inner|safeHTML}}
 
 {{ define "childs" }}
-	{{ range .menu }}
-		{{ if and .Params.hidden (not $.showhidden) }} 
-		{{else}}
-  
-
-{{if hasPrefix $.style "h"}}
-	{{$num := sub ( int (trim $.style "h") ) 1 }}
-	{{$numn := add $num $.count }}
-
-{{(printf "<h%d>" $numn)|safeHTML}}
-<a href="{{.URL}}" >{{ .Title }}</a>
-{{(printf "</h%d>" $numn)|safeHTML}}
-
-{{else}}
-{{(printf "<%s>" $.style)|safeHTML}}
-<a href="{{.URL}}" >{{ .Title }}</a>
-{{(printf "</%s>" $.style)|safeHTML}}
-{{end}}
+	{{- range .menu }}
+		{{- if and .Params.hidden (not $.showhidden) }}
+		{{- else}}
 
 
+{{- if hasPrefix $.style "h"}}
+	{{- $num := sub ( int (trim $.style "h") ) 1 }}
+	{{- $numn := add $num $.count }}
+
+{{- (printf "<h%d>" $numn)|safeHTML}}
+	<a href="{{.URL}}" >{{ .Title }}</a>
+{{- (printf "</h%d>" $numn)|safeHTML}}
+
+{{- else}}
+{{- (printf "<%s>" $.style)|safeHTML}}
+	<a href="{{.URL}}" >{{ .Title }}</a>
+{{- (printf "</%s>" $.style)|safeHTML}}
+{{- end}}
 
 
 
-			{{if $.description}}
-				{{if .Description}}
+
+
+			{{- if $.description}}
+				{{- if .Description}}
 <p>{{.Description}}</p>
-				{{else}}
+				{{- else}}
 <p>{{.Summary}}</p>
-				{{end}}
-			{{end}}
-		
+				{{- end}}
+			{{- end}}
 
-		
-			{{ if lt $.count $.depth}}
-{{if eq $.style "li"}}
+
+
+			{{- if lt $.count $.depth}}
+{{- if eq $.style "li" }}
 <ul>
-{{end}}
-	{{ .Scratch.Set "pages" .Pages }}
-    {{ if .Sections}}
-	    {{ .Scratch.Set "pages" (.Pages | union .Sections) }}
-    {{end}}
-    {{ $pages := (.Scratch.Get "pages") }}
+{{- end}}
+	{{- .Scratch.Set "pages" .Pages }}
+    {{- if .Sections}}
+	    {{- .Scratch.Set "pages" (.Pages | union .Sections) }}
+    {{- end}}
+    {{- $pages := (.Scratch.Get "pages") }}
 
-	{{if eq $.sortTerm "Weight"}}
-		{{template "childs" dict "menu" $pages.ByWeight  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
-	{{else if eq $.sortTerm "Name"}}
-		{{template "childs" dict "menu" $pages.ByTitle  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
-	{{else if eq $.sortTerm "PublishDate"}}
-		{{template "childs" dict "menu" $pages.ByPublishDate  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
-	{{else if eq $.sortTerm "Date"}}
-		{{template "childs" dict "menu" $pages.ByDate  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
-	{{else if eq $.sortTerm "Length"}}
-		{{template "childs" dict "menu" $pages.ByLength  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
-	{{else}}
-		{{template "childs" dict "menu" $pages  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
-	{{end}}
-{{if eq $.style "li"}}
+	{{- if eq $.sortTerm "Weight"}}
+		{{- template "childs" dict "menu" $pages.ByWeight  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+	{{- else if eq $.sortTerm "Name"}}
+		{{- template "childs" dict "menu" $pages.ByTitle  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+	{{- else if eq $.sortTerm "PublishDate"}}
+		{{- template "childs" dict "menu" $pages.ByPublishDate  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+	{{- else if eq $.sortTerm "Date"}}
+		{{- template "childs" dict "menu" $pages.ByDate  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+	{{- else if eq $.sortTerm "Length"}}
+		{{- template "childs" dict "menu" $pages.ByLength  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+	{{- else}}
+		{{- template "childs" dict "menu" $pages  "style" $.style "showhidden" $.showhidden "count" (add $.count 1) "depth" $.depth "pages" $.pages "description" $.description "sortTerm" $.sortTerm}}
+	{{- end}}
+{{- if eq $.style "li"}}
 </ul>
-{{end}}
-			{{end}}
+{{- end }}
+			{{- end }}
 
-		{{end}}
-	{{end}}
-{{end}}
+		{{- end }}
+	{{- end }}
+{{- end }}


### PR DESCRIPTION
Hi @vjeantet,

This PR solves #61 issue.

It would be good to review this sooner rather than later, as many lines enhanced. Already had merge issues doing rebase on my local copy (Actually first time when used rebase function). 

Though _little_ change is adding `-` to `{{ ... }}` brackets, it affects lot of lines of core files. It is not done blindly, just enough to keep HTML readable.

P.S. Did also some benchmarks with `hugo benchmark` (Hugo 0.27.1/0.25.1, content: 21x md file with images, some bulk text) and difference **before** and **after** this change is negligible. Maybe @GeertvanHorrik could do benchmark on his huge docs site.