### PR TITLE
change French size abbr. ko to English size abbr. kB

### DIFF
--- a/layouts/shortcodes/attachments.html
+++ b/layouts/shortcodes/attachments.html
@@ -16,7 +16,7 @@
 					<a href="{{ printf "%s/%s%s/%s" $.Site.BaseURL $fileDir ($.Scratch.Get "filesName") .Name }}" >
 						{{.Name}}
 					</a>
-					({{div .Size 1024 }} ko)
+					({{div .Size 1024 }} kB)
 				</li>
 			{{end}}
 		{{else}}
@@ -24,7 +24,7 @@
 				<a href="{{ printf "%s/%s%s/%s" $.Site.BaseURL $fileDir ($.Scratch.Get "filesName") .Name }}" >
 					{{.Name}}
 				</a>
-				({{div .Size 1024 }} ko)
+				({{div .Size 1024 }} kB)
 			</li>
 		{{end}}
 	{{end}}


### PR DESCRIPTION
Just a minor thing: instead of the French kilo-octet <ko> use the Englisch kilobyte <kB>