### PR TITLE
Get UTF-8 right in slides

### DIFF
--- a/layouts/slide/single.html
+++ b/layouts/slide/single.html
@@ -1,3 +1,4 @@
+	<head><meta charset="utf-8"></head>
 
 	<link rel="stylesheet" href="{{"revealjs/css/reveal.css"|relURL}}">
 	<link rel="stylesheet" href="{{"revealjs/css/theme/"|relURL}}{{.Params.theme}}.css" id="theme">
@@ -8,8 +9,7 @@
 	<section data-markdown
 	         data-separator="^---"
 		 data-separator-vertical="^___"
-		 data-separator-notes="^Note:"
-		data-charset="utf8">
+		 data-separator-notes="^Note:">
 	{{ .RawContent }}
 	</section>
 	</div>


### PR DESCRIPTION
Spanish accents at least (á é ...) were not working correctly after uploading.