### PR TITLE
resolve css conflict with Pandoc rendering (.Rmd files)

### DIFF
--- a/static/mermaid/mermaid.css
+++ b/static/mermaid/mermaid.css
@@ -91,7 +91,7 @@ text.actor {
 /** Section styling */
 .section {
   stroke: none;
-  opacity: 0.2;
+  opacity: 1; /* changed from 0.2; because of conflicts with Pandoc rendering in .Rmd files */
 }
 .section0 {
   fill: rgba(102, 102, 255, 0.49);

--- a/static/mermaid/mermaid.dark.css
+++ b/static/mermaid/mermaid.dark.css
@@ -91,7 +91,7 @@ text.actor {
 /** Section styling */
 .section {
   stroke: none;
-  opacity: 0.2;
+  opacity: 1; /* changed from 0.2; because of conflicts with Pandoc rendering in .Rmd files */
 }
 .section0 {
   fill: rgba(255, 255, 255, 0.3);

--- a/static/mermaid/mermaid.forest.css
+++ b/static/mermaid/mermaid.forest.css
@@ -93,7 +93,7 @@ text.actor {
 /** Section styling */
 .section {
   stroke: none;
-  opacity: 0.2;
+  opacity: 1; /* changed from 0.2; because of conflicts with Pandoc rendering in .Rmd files */
 }
 .section0 {
   fill: #6eaa49;


### PR DESCRIPTION
After headers (e.g. `# title`) all following text appear in a light gray. Details about the issue can be found in [issue 71](https://github.com/vjeantet/hugo-theme-docdock/issues/71).