### PR TITLE
Allows hiding of whole sections.

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -61,7 +61,7 @@
 {{- $showvisitedlinks := .showvisitedlinks }}
 {{- $currentNode := .currentnode }}
  {{- with .sect}}
-  {{- if .IsSection}}
+  {{- if and .IsSection (or (not .Params.hidden) $.showhidden)}}
     {{- safeHTML .Params.head}}
     <li data-nav-id="{{.URL}}" class="dd-item
         {{- if .IsAncestor $currentNode}} parent{{end}}


### PR DESCRIPTION
`hidden: true` was only working for subsections. This makes it work on the main sections too.