### PR TITLE
fix: error on mermaid graphs with search

### DIFF
--- a/static/js/learn.js
+++ b/static/js/learn.js
@@ -284,7 +284,7 @@ jQuery.extend({
     highlight: function(node, re, nodeName, className) {
         if (node.nodeType === 3) {
             var match = node.data.match(re);
-            if (match) {
+            if (match && !$(node.parentNode).hasClass("mermaid")) {
                 var highlight = document.createElement(nodeName || 'span');
                 highlight.className = className || 'highlight';
                 var wordNode = node.splitText(match.index);


### PR DESCRIPTION
If you search a value which match a mermaid graph text, the graph will not be displayed due to highlighting which breaks the mermaid syntax