### PR TITLE
Multilanguage: show selector and redirect home properly

### DIFF
--- a/layouts/partials/flex/body-beforecontent.html
+++ b/layouts/partials/flex/body-beforecontent.html
@@ -1,6 +1,7 @@
 <header>
   <div class="logo">
-      {{ range where .Site.Pages "Source.BaseFileName" "_header" }} 
+      {{ $header := print "_header." .Lang }}
+      {{ range where .Site.Pages "Source.BaseFileName" $header }}
         {{ .Content }} 
       {{else}}
         <span style="font-size:smaller">
@@ -26,8 +27,8 @@
   <nav>
     <ul class="topics">
       {{- if not .Site.Params.disableHomeIcon}}
-          <li data-nav-id="{{"/" | relURL}}" class="dd-item">
-          <a href="{{"/" | relURL}}">
+          <li data-nav-id="{{"/" | relLangURL}}" class="dd-item">
+          <a href="{{"/" | relLangURL}}">
             <i class="fa fa-fw fa-home"></i>
           </a>
           </li>

--- a/layouts/partials/original/body-beforecontent.html
+++ b/layouts/partials/original/body-beforecontent.html
@@ -6,7 +6,8 @@
 <div class="highlightable">
   <div id="header-wrapper">
     <div id="header">
-		{{ range where .Site.Pages "Source.BaseFileName" "_header" }} 
+    {{ $header := print "_header." .Lang }}
+		{{ range where .Site.Pages "Source.BaseFileName" $header }}
 		{{ .Content }} 
 		{{else}}
 		<span style="font-size:smaller">
@@ -34,8 +35,8 @@
 
       <ul class="topics">
         {{- if not .Site.Params.disableHomeIcon}}
-            <li data-nav-id="{{"/" | relURL}}" class="dd-item">
-            <a href="{{"/" | relURL}}"><i class="fa fa-fw fa-home"></i></a>
+            <li data-nav-id="{{"/" | relLangURL}}" class="dd-item">
+            <a href="{{"/" | relLangURL}}"><i class="fa fa-fw fa-home"></i></a>
             </li>
         {{- end}}
 		
@@ -56,7 +57,31 @@
             <a id="clear-history" class="" href="#" data-clear-history-toggle=""><i class="fa  fa-history"></i> {{T "Clear-History"}}</a>
         {{- end}}
 
-        {{- end}}
+		{{- end}}
+
+		<hr />
+		{{- if and .Site.IsMultiLingual (not .Site.Params.DisableLanguageSwitchingButton)}}
+		<li>
+			<select id="select-language" onchange="location = this.value;">
+				{{ $siteLanguages := .Site.Languages}}
+				{{ $pageLang := .Page.Lang}}
+				{{ range .Page.AllTranslations }}
+					{{ $translation := .}}
+					{{ range $siteLanguages }}
+						{{ if eq $translation.Lang .Lang }}
+							{{ if eq $pageLang .Lang}}
+								<option id="{{ $translation.Language }}" value="{{ $translation.URL }}" selected>{{ .LanguageName }}</option>
+							{{ else }}
+								<option id="{{ $translation.Language }}" value="{{ $translation.URL }}">{{ .LanguageName }}</option>
+							{{ end }}
+						{{ end }}
+					{{ end }}
+				{{ end }}
+			</select>
+		</li>
+		{{- end }}
+
+
     </ul>
 
  <section id="footer">

--- a/static/scss/original/main.scss
+++ b/static/scss/original/main.scss
@@ -1137,7 +1137,7 @@ td {
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
-    width: calc(100% - 120px);
+    width: calc(100% - 150px);
 }
 
 #body #breadcrumbs .links {

--- a/static/theme-original/style.css
+++ b/static/theme-original/style.css
@@ -1031,7 +1031,7 @@ td {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  width: calc(100% - 120px); }
+  width: calc(100% - 150px); }
 
 #body #breadcrumbs .links {
   font-size: 0.8em; }


### PR DESCRIPTION
The goal of this PR is to show a selector with the languages available for multilanguage sites using this template.

This merge changes:

- Home icon redirect to the specific home language.
- Select in the menu to be able to change the language if the site is multilanguage. This select can be disabled even when the site has more than one language by adding to the config: 
```
disableLanguageSwitchingButton = true
```

I've created this hugo site project to test these changes: https://github.com/jose-oc/test-hugo-theme-docdock

Thanks to @xxxtonixxx