### PR TITLE
Allow to search on multilanguage sites.

### DIFF
--- a/exampleSite/content/search/_index.md
+++ b/exampleSite/content/search/_index.md
@@ -10,4 +10,4 @@ weight = 40
 Docdock theme uses the last improvement available in hugo version 20+ to generate a json index file ready to be consumed by lunr.js javascript search engine.
 
 
-{{%note%}}hugo generate lunrjs index.json at the root of `public` folder. <br/>When you build the site with `hugo server`, hugo generates it internally and of course it don't show up in the filesystem{{%/note%}}
+{{%note%}}hugo generate lunrjs index.json at the root of `public` folder if the site only has one language or within each language subfolder. <br/>When you build the site with `hugo server`, hugo generates it internally and of course it don't show up in the filesystem{{%/note%}}

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -4,6 +4,35 @@ function endsWith(str, suffix) {
     return str.indexOf(suffix, str.length - suffix.length) !== -1;
 }
 
+function buildJsonIndexURL() {
+    var jsonIndexUrl = baseurl + "index.json";
+    var language = "";
+    var currentPathname = window.location.pathname;
+
+    var currentPathnameSplitted = currentPathname.split("/");
+    if (currentPathnameSplitted.length >0) {
+        language = currentPathnameSplitted[1] + "/";
+    }
+
+    jsonFileWithinLanguageFolderExists = $.ajax({
+        url:baseurl + language + 'index.json',
+        type:'HEAD',
+        error: function() {
+            return false;
+        },
+        success: function() {
+            return true;
+        }
+    });
+
+    if (jsonFileWithinLanguageFolderExists) {
+        jsonIndexUrl = baseurl + language + "index.json";
+    } else {
+        jsonIndexUrl = baseurl + "index.json";
+    }
+    return jsonIndexUrl;
+}
+
 // Initialize lunrjs using our generated index file
 function initLunr() {
     if (!endsWith(baseurl,"/")){
@@ -11,7 +40,9 @@ function initLunr() {
     };
 
     // First retrieve the index file
-    $.getJSON(baseurl +"index.json")
+    var jsonIndexUrl = buildJsonIndexURL();
+
+    $.getJSON(jsonIndexUrl)
         .done(function(index) {
             pagesIndex =   index;
             // Set up lunrjs by declaring the fields we use
@@ -36,7 +67,7 @@ function initLunr() {
         })
         .fail(function(jqxhr, textStatus, error) {
             var err = textStatus + ", " + error;
-            console.error("Error getting Hugo index flie:", err);
+            console.error("Error getting Hugo index file:", err);
         });
 }
 


### PR DESCRIPTION
Using the search in a multi-language site it fails. This PR solves this issue.

lunrjs was trying to get the file index.json from the root while when the site is multilanguage there are more than one index.json, one per language and living within a folder called as the language, so at the moment on a multi-language site it gets a 404 trying to get the index.json file.

This PR tries to locate the file index.json according to the language specified in the URL of the current page or failing over the root path.
