### PR TITLE
Fix clippy.svg location for multilanguage sites

### DIFF
--- a/static/js/docdock.js
+++ b/static/js/docdock.js
@@ -186,7 +186,7 @@ jQuery(document).ready(function() {
                 clipInit = true;
             }
 
-            code.after('<span class="copy-to-clipboard" title="Copy to clipboard"><object class="clippy-icon" type="image/svg+xml" data="'+baseurl+'/images/clippy.svg"/></span>');
+            code.after('<span class="copy-to-clipboard" title="Copy to clipboard"><object class="clippy-icon" type="image/svg+xml" data="'+window.location.origin+'/images/clippy.svg"/></span>');
             code.next('.copy-to-clipboard').on('mouseleave', function() {
                 $(this).attr('aria-label', null).removeClass('tooltipped tooltipped-s tooltipped-w');
             });


### PR DESCRIPTION
In multi-language sites the icon clippy.svg is wrongly pointed. 
They are being got using an URL like this one: http://localhost:1313//en//images/clippy.svg but the image actually lives in http://localhost:1313/images/clippy.svg

This is easily solved using `window.location.origin` instead of the javascript variable `baseurl`.