### PR TITLE
fix LinkTitle in menu

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -69,7 +69,7 @@
      {{- if eq .URL $currentNode.URL}} active{{end -}}
       ">
         <a href="{{ .RelPermalink}}">
-          <span>{{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}</span>
+          <span>{{safeHTML .Params.Pre}}{{.LinkTitle}}{{safeHTML .Params.Post}}</span>
           {{- if $showvisitedlinks}}<i class="fa fa-circle-thin read-icon"></i>{{end}}
         </a>
     </li>


### PR DESCRIPTION
this is a change to fix the use of linktitle vs title as the link name in the menu.

title is still the headline on top of the page.

linktitle overrules title as the name of links.
this is the default gohugo behavior https://gohugo.io/templates/lists/#by-link-title



as a sidenote: started yesterday using hugo and this theme. i enjoy it a lot. thanks.