### PR TITLE
feat: add 'disqus' comment feature to each page

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -3,6 +3,7 @@ title= "{{ replace .TranslationBaseName "-" " " | title }}"
 date= {{ .Date }}
 description = ""
 draft= true
+disqusShortname= ""
 +++
 
 Lorem Ipsum.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -12,6 +12,7 @@ defaultContentLanguage = "en"
 defaultContentLanguageInSubdir= false
 enableMissingTranslationPlaceholders = false
 
+disqusShortname = ""
 
 # [Languages]
 # [Languages.en]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -18,6 +18,8 @@
     {{ block "main" . }}
     {{ end }}
     
+    {{ partial "disqus.html" . }}
+
     {{if .Site.Params.themeStyle}}
       {{ partial (printf "%s/body-aftercontent.html" .Site.Params.themeStyle) . }}
     {{else}}

--- a/layouts/partials/disqus.html
+++ b/layouts/partials/disqus.html
@@ -1,0 +1,42 @@
+<div id="disqus_thread"></div>
+<script>
+    /**
+     *  RECOMMENDED CONFIGURATION VARIABLES: EDIT AND UNCOMMENT 
+     *  THE SECTION BELOW TO INSERT DYNAMIC VALUES FROM YOUR 
+     *  PLATFORM OR CMS.
+     *
+     *  LEARN WHY DEFINING THESE VARIABLES IS IMPORTANT: 
+     *  https://disqus.com/admin/universalcode/#configuration-variables
+     */
+    var disqus_config = function () {
+        this.page.url = {{ .Permalink }};
+        this.page.identifier = {{ .URL }};
+    };
+
+    (function() {
+        var d = document, s = d.createElement('script');
+
+        {{ $pageShortname := trim .Params.disqusShortname " \t" }}
+        {{ $siteShortname := trim .Site.DisqusShortname  " \t" }}
+
+        {{ if $pageShortname }}
+            var shortName = '{{ $pageShortname }}';
+        {{ else }}
+            var shortName = '{{ $siteShortname }}';
+        {{ end }}
+
+        if (shortName == '') {
+            return;
+        }
+
+        s.src = 'https://' + shortName + '.disqus.com/embed.js';
+        s.setAttribute('data-timestamp', +new Date());
+        (d.head || d.body).appendChild(s);
+    })();
+</script>
+<noscript>
+    Please enable JavaScript to view the 
+    <a href="https://disqus.com/?ref_noscript" rel="nofollow">
+        comments powered by Disqus.
+    </a>
+</noscript>


### PR DESCRIPTION
Hi,

I use docdock for some time, and I miss the comment feature like 'disqus' which is useful for document sharing. This pull request adds the 'disqus' commenting feature.

It works this way:
1. To enable the feature, add ''disqusShortname' into 'config.toml' or each page's param field. Empty or missing such config would disable the feature.
2. Each page has higher priority than global config. And it could be specified a different short name  consider that single page is created by another people in the team.
3. It falls back to the global config.toml if the page's config is missing.

I've tested with both original/flex themes.

Thanks,