### PR TITLE
Add LinkTitle for _index.md pages

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -26,7 +26,7 @@
         {{- if ne $numberOfPages 0 }} haschildren{{end}}
         ">
       <div>
-      <a href="{{ .RelPermalink}}">{{safeHTML .Params.Pre}}{{.Title}}{{safeHTML .Params.Post}}</a>
+      <a href="{{ .RelPermalink}}">{{safeHTML .Params.Pre}}{{.LinkTitle}}{{safeHTML .Params.Post}}</a>
         
         {{- if ne $numberOfPages 0 }}
           {{- if or (.IsAncestor $currentNode) (.Params.alwaysopen) }}


### PR DESCRIPTION
The front matter value for `LinkTitle` is not being rendered for `_index.md` pages. This small change allows theme users to set the `LinkTitle` explicitly in front matter to control the width of text in the navigation and would make menu titles consistent for all pages.