### PR TITLE
Make "Improve this page" link in footer optional

### DIFF
--- a/layouts/partials/flex/body-aftercontent.html
+++ b/layouts/partials/flex/body-aftercontent.html
@@ -22,16 +22,18 @@
     </div>
     {{end}}
 
-  {{ if not .Page.Lastmod.IsZero }}
+    {{ if not .Page.Lastmod.IsZero }}
     <div class="date">
         <i class='fa fa-calendar'></i> {{T "last-update-on"}} {{ .Page.Lastmod.Format "02/01/2006" }}
     </div>
     {{end}}
 
+    {{ if .Site.Params.editURL }}
     <div class="github-link">
       <a href="{{ .Site.Params.editURL }}{{ replace .File.Dir "\\" "/" }}{{ .File.LogicalName }}" target="blank"><i class="fa fa-code-fork"></i>
         {{T "Edit-this-page"}}</a>
     </div>
+    {{end}}
   </div>
 
 


### PR DESCRIPTION
Hello @vjeantet,

Love the project and thanks for your work. My docdock repo is not stored in GitHub and I'm unable to make this link work with my VCS. Can we please make this div optional and present only if a user has configured the editURL param?

I've tested this and it works fine both ways, editURL specified and absent.

Regards,
Chris