### PR TITLE
Correct a typo for attachments in a folder

### DIFF
--- a/layouts/shortcodes/attachments.html
+++ b/layouts/shortcodes/attachments.html
@@ -3,7 +3,7 @@
 		<span class="glyphicon glyphicon-paperclip" aria-hidden="true"></span>
 		{{with .Get "title"}}{{.}}{{else}}{{T "Attachments-label"}}{{end}}
 	</label>
-	{{if eq .Page.File.BaseFileName "index"}}
+	{{if eq .Page.File.BaseFileName "_index"}}
 		{{$.Scratch.Add "filesName" "files"}}
 	{{else}}
 		{{$.Scratch.Add "filesName" (printf "%s.files" .Page.File.BaseFileName)}}


### PR DESCRIPTION
At the moment the shortcode  do not work as expected when you are in a folder/_index.md page (works fine for a foo.md page):

folder
   |-- _index.html
   |-- files
           |
           |-- foo.pdf