### PR TITLE
Correct a bug (since 0.50) in partials/header.html

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 {{ $header := print "_header." .Lang }}
-	{{ range where .Site.Pages "Source.BaseFileName" $header }}
+	{{ range where .Site.Pages ".File.BaseFileName" $header }}
 	{{ .Content }} 
 	{{else}}
   {{ if .Site.GetPage "page" "_header.md" }}


### PR DESCRIPTION
Close #166


`Source ` seems not to be well documented, and obviously changed in 0.50

According to my understanding of what this partiel is doing,  `.Page` seems correct and works the same.