### PR TITLE
hugo 0.50 compatibility

### DIFF
--- a/layouts/partials/flex/body-aftercontent.html
+++ b/layouts/partials/flex/body-aftercontent.html
@@ -39,7 +39,7 @@
 
 	<div>
 {{ $footer := print "_footer." .Lang }}
-{{ range where .Site.Pages "Source.BaseFileName" $footer }}
+{{ range where .Site.Pages "File.BaseFileName" $footer }}
   {{ .Content }} 
 {{else}}
   {{ if .Site.GetPage "page" "_footer.md" }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 {{ $header := print "_header." .Lang }}
-	{{ range where .Site.Pages "Source.BaseFileName" $header }}
+	{{ range where .Site.Pages "File.BaseFileName" $header }}
 	{{ .Content }} 
 	{{else}}
   {{ if .Site.GetPage "page" "_header.md" }}


### PR DESCRIPTION
Apparently Source was renamed to File in Hugo 0.50; I updated the templates to match.

It's probably not backwards compatible with Hugo 0.49.