### PR TITLE
Add PT-BR (Brazilian Portuguese) translation

### DIFF
--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -1,0 +1,44 @@
+[create-header-md]
+other = "Crie um arquivo content/_header.md para customizar isto"
+
+[create-footer-md]
+other = "Crie um arquivo content/_footer.md para customizar o conteúdo do rodapé"
+
+[Search-placeholder]
+other = "Buscar..."
+
+[Clear-History]
+other = "Limpar Histórico"
+
+[Page]
+other = "Página"
+
+[Next-Pages]
+other = "Próximas Páginas"
+
+[Previous-Pages]
+other = "Páginas Anteriores"
+
+[pagination-on]
+other = "de"
+
+[Attachments-label]
+other = "Anexos"
+
+[title-404]
+other = "Erro"
+
+[message-404]
+other = "Woops. Esta página não existe."
+
+[Go-to-homepage]
+other = "Página Principal"
+
+[Edit-this-page]
+other = "Melhorar esta página"
+
+[Expand-title]
+other = "Expandir..."
+
+[last-update-on]
+other = "Última atualização em"


### PR DESCRIPTION
This is my proposed PT-BR translation for the theme. Theme users can set the site language to `pt-br` and the theme should show Braziliam Portuguese default texts.