### PR TITLE
fixed line overlap when wrapping h1 and h2

### DIFF
--- a/static/css/nucleus.css
+++ b/static/css/nucleus.css
@@ -510,10 +510,14 @@ h1, h2, h3, h4, h5, h6 {
   text-rendering: optimizeLegibility; }
 
 h1 {
-  font-size: 3.25rem; }
+  font-size: 3.25rem; 
+  line-height: 3.20rem;
+}
 
 h2 {
-  font-size: 2.55rem; }
+  font-size: 2.55rem; 
+  line-height: 2.50rem;
+}
 
 h3 {
   font-size: 2.15rem; }

--- a/static/css/nucleus.css
+++ b/static/css/nucleus.css
@@ -543,7 +543,8 @@ ul, ol {
 
 blockquote {
   margin: 1.7rem 0;
-  padding-left: 0.85rem; }
+  padding-left: 0.85rem; 
+  border-left: 0.2rem dotted red}
 
 cite {
   display: block;


### PR DESCRIPTION
When h1 or h2 text is too long it gets wrapped.  The wrapped 2nd line does not have enough vertical space and starts overriding top line.  The solution is to add more space between lines.

spacing might need to be specified even bigger.
other headers might require update.