### PR TITLE
Fixes menu build issues when concurrently building multiple pages

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -40,11 +40,10 @@
       </div>
       {{- if ne $numberOfPages 0 }}
         <ul>
-          {{- .Scratch.Set "pages" .Pages }}
+          {{- $pages := .Pages }}
           {{- if .Sections}}
-          {{- .Scratch.Set "pages" (.Pages | union .Sections) }}
+          {{- $pages = (.Pages | union .Sections) }}
           {{- end}}
-          {{- $pages := (.Scratch.Get "pages") }}
 
         {{- if eq .Site.Params.ordersectionsby "title"}}
           {{- range $pages.ByTitle }}


### PR DESCRIPTION
We faced an issue when using with lots of documents (400+) and building to publish (not serve). After debugging the issue was using the public `.Stratch` method. Changing to a local scratch variable method would solve, but in this use case I believe it is not necessary and the current approached was used. Solved our problem.