### PR TITLE
fix: broken lunr and autocomplete

### DIFF
--- a/layouts/partials/flex/body-beforecontent.html
+++ b/layouts/partials/flex/body-beforecontent.html
@@ -50,17 +50,6 @@
         <div class="searchbox">
           <input data-search-input id="search-by" type="text" placeholder="{{T "Search-placeholder"}}">
         </div>
-        <script type="text/javascript" src="{{"js/lunr.min.js" | relURL}}"></script>
-        <script type="text/javascript" src="{{"js/auto-complete.js" | relURL}}"></script>
-        <link href="{{"css/auto-complete.css" | relURL}}" rel="stylesheet">
-        <script type="text/javascript">
-          {{ if .Site.IsMultiLingual }}
-              var baseurl = "{{.Site.BaseURL}}{{.Site.LanguagePrefix}}";
-          {{ else }}
-              var baseurl = "{{.Site.BaseURL}}";
-          {{ end }}
-        </script>
-        <script type="text/javascript" src="{{"js/search.js" | relURL}}"></script>
       </div>
     {{- end}}
     

--- a/layouts/partials/flex/head.html
+++ b/layouts/partials/flex/head.html
@@ -6,6 +6,7 @@
 <link href="{{"css/nucleus.css" | relURL}}" rel="stylesheet">
 <link href="{{"css/font-awesome.min.css" | relURL}}" rel="stylesheet">
 <link href="{{"css/featherlight.min.css" | relURL}}" rel="stylesheet">
+<link href="{{"css/auto-complete.css" | relURL}}" rel="stylesheet">
 <link href="{{(printf "theme-%s/style.css" (.Site.Params.themeStyle| default "flex")  ) | relURL}}" rel="stylesheet">
 {{with .Site.Params.themeVariant}}
 	<link href="{{(printf "theme-%s/variant-%s.css" ($.Site.Params.themeStyle| default "flex") .) | relURL}}" rel="stylesheet">

--- a/layouts/partials/flex/scripts.html
+++ b/layouts/partials/flex/scripts.html
@@ -1,6 +1,10 @@
 <script src="{{"js/jquery-2.x.min.js" | relURL}}"></script>
 <script type="text/javascript">
-      var baseurl = "{{.Site.BaseURL}}";
+    {{if .Site.IsMultiLingual}}
+        var baseurl = "{{.Site.BaseURL}}{{.Site.LanguagePrefix}}";
+    {{else}}
+        var baseurl = "{{.Site.BaseURL}}";
+    {{end}}
 </script>
 <script src="{{"js/clipboard.min.js" | relURL}}"></script>
 <script src="{{"js/featherlight.min.js" | relURL}}"></script>
@@ -8,4 +12,7 @@
 <script src="{{"js/highlight.pack.js" | relURL}}"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 {{end}}
+<script type="text/javascript" src="{{"js/lunr.min.js" | relURL}}"></script>
+<script type="text/javascript" src="{{"js/auto-complete.js" | relURL}}"></script>
+<script type="text/javascript" src="{{"js/search.js" | relURL}}"></script>
 <script src="{{(printf "theme-%s/script.js" (.Site.Params.themeStyle| default "flex")) | relURL}}"></script>

--- a/layouts/partials/original/body-beforecontent.html
+++ b/layouts/partials/original/body-beforecontent.html
@@ -14,16 +14,6 @@
 		    <input data-search-input id="search-by" type="text" placeholder="{{T "Search-placeholder"}}">
 		    <span data-search-clear=""><i class="fa fa-close"></i></span>
 		</div>
-		<script type="text/javascript" src="{{"js/lunr.min.js" | relURL}}"></script>
-		<script type="text/javascript" src="{{"js/auto-complete.js" | relURL}}"></script>
-		<script type="text/javascript">
-        {{ if .Site.IsMultiLingual }}
-            var baseurl = "{{.Site.BaseURL}}{{.Site.LanguagePrefix}}";
-        {{ else }}
-            var baseurl = "{{.Site.BaseURL}}";
-        {{ end }}
-		</script>
-		<script type="text/javascript" src="{{"js/search.js" | relURL}}"></script>
     {{- end}}
   </div>
 

--- a/layouts/partials/original/scripts.html
+++ b/layouts/partials/original/scripts.html
@@ -1,4 +1,11 @@
 <script src="{{"js/jquery-2.x.min.js" | relURL}}"></script>
+<script type="text/javascript">
+    {{if .Site.IsMultiLingual}}
+        var baseurl = "{{.Site.BaseURL}}{{.Site.LanguagePrefix}}";
+    {{else}}
+        var baseurl = "{{.Site.BaseURL}}";
+    {{end}}
+</script>
 <script src="{{"js/clipboard.min.js" | relURL}}"></script>
 <script src="{{"js/featherlight.min.js" | relURL}}"></script>
 <script src="{{"js/html5shiv-printshiv.min.js" | relURL}}"></script>
@@ -8,4 +15,7 @@
 {{end}}
 <script src="{{"js/modernizr.custom.71422.js" | relURL}}"></script>
 <script src="{{"js/docdock.js" | relURL}}"></script>
+<script type="text/javascript" src="{{"js/lunr.min.js" | relURL}}"></script>
+<script type="text/javascript" src="{{"js/auto-complete.js" | relURL}}"></script>
+<script type="text/javascript" src="{{"js/search.js" | relURL}}"></script>
 <script src="{{"theme-original/script.js" | relURL}}"></script>


### PR DESCRIPTION
In order to improve page load speed, some scripts was defer to the end of the page (Jquery include -> https://github.com/vjeantet/hugo-theme-docdock/pull/213). Unfortunately, some scripts have been forgotten ... and this PR fixes them.