### PR TITLE
Fix over-scrolling when clicking a link to heading

### DIFF
--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -430,6 +430,9 @@ h5:hover .anchor,
 h6:hover .anchor {
   visibility: visible; }
 
+h1, h2, h3, h4, h5, h6 {
+  scroll-margin-top: 5.7rem; }
+
 .tooltipped {
   position: relative; }
 


### PR DESCRIPTION
Add scroll-margin-top property to headings when using the "flex" style
to prevent the nav bar from covering the heading text when navigating
there from a link.

Fixes #191 