### PR TITLE
Fix deprecated `.Site.IsMultiLingual` -> `hugo.IsMultilingual`

### DIFF
--- a/layouts/partials/flex/scripts.html
+++ b/layouts/partials/flex/scripts.html
@@ -1,6 +1,6 @@
 <script src="{{"js/jquery-2.x.min.js" | relURL}}"></script>
 <script type="text/javascript">
-    {{if .Site.IsMultiLingual}}
+    {{if hugo.IsMultilingual}}
         var baseurl = "{{.Site.BaseURL}}{{.Site.LanguagePrefix}}";
     {{else}}
         var baseurl = "{{.Site.BaseURL}}";

--- a/layouts/partials/language-selector.html
+++ b/layouts/partials/language-selector.html
@@ -1,4 +1,4 @@
-{{- if and .Site.IsMultiLingual (not .Site.Params.DisableLanguageSwitchingButton)}}
+{{- if and hugo.IsMultilingual (not .Site.Params.DisableLanguageSwitchingButton)}}
 <select id="select-language" onchange="location = this.value;">
 	{{ $siteLanguages := .Site.Languages}}
 	{{ $pageLang := .Page.Lang}}

--- a/layouts/partials/original/scripts.html
+++ b/layouts/partials/original/scripts.html
@@ -1,6 +1,6 @@
 <script src="{{"js/jquery-2.x.min.js" | relURL}}"></script>
 <script type="text/javascript">
-    {{if .Site.IsMultiLingual}}
+    {{if hugo.IsMultilingual}}
         var baseurl = "{{.Site.BaseURL}}{{.Site.LanguagePrefix}}";
     {{else}}
         var baseurl = "{{.Site.BaseURL}}";


### PR DESCRIPTION
See gohugoio/hugo#12224. The deprecation warning for this has become an error as of Hugo 0.136, preventing sites using this theme from building successfully.